### PR TITLE
Fix the cuda issue for long prompt inference

### DIFF
--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -22,7 +22,6 @@
 #include "attention_utils.cuh"
 
 #include <algorithm>
-#include <iostream>
 
 #define WARP_SIZE 32
 #define MAX(a, b) ((a) > (b) ? (a) : (b))

--- a/csrc/cuda_utils.cpp
+++ b/csrc/cuda_utils.cpp
@@ -1,0 +1,12 @@
+#include <torch/extension.h>
+
+int get_device_attribute(
+    int attribute,
+    int device_id);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+    "get_device_attribute",
+    &get_device_attribute,
+    "Gets the specified device attribute.");
+}

--- a/csrc/cuda_utils_kernels.cu
+++ b/csrc/cuda_utils_kernels.cu
@@ -1,0 +1,14 @@
+int get_device_attribute(
+    int attribute,
+    int device_id)
+{
+    int device, value;
+    if (device_id < 0) {
+        cudaGetDevice(&device);
+    }
+    else {
+        device = device_id;
+    }
+    cudaDeviceGetAttribute(&value, static_cast<cudaDeviceAttr>(attribute), device);
+    return value;
+}

--- a/setup.py
+++ b/setup.py
@@ -89,29 +89,39 @@ attention_extension = CUDAExtension(
 ext_modules.append(attention_extension)
 
 # Positional encoding kernels.
-# positional_encoding_extension = CUDAExtension(
-#     name="vllm.pos_encoding_ops",
-#     sources=["csrc/pos_encoding.cpp", "csrc/pos_encoding_kernels.cu"],
-#     extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
-# )
-# ext_modules.append(positional_encoding_extension)
+positional_encoding_extension = CUDAExtension(
+    name="vllm_pos_encoding_ops",
+    sources=["csrc/pos_encoding.cpp", "csrc/pos_encoding_kernels.cu"],
+    extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
+)
+ext_modules.append(positional_encoding_extension)
 
 # Layer normalization kernels.
-# layernorm_extension = CUDAExtension(
-#     name="vllm.layernorm_ops",
-#     sources=["csrc/layernorm.cpp", "csrc/layernorm_kernels.cu"],
-#     extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
-# )
-# ext_modules.append(layernorm_extension)
+layernorm_extension = CUDAExtension(
+    name="vllm_layernorm_ops",
+    sources=["csrc/layernorm.cpp", "csrc/layernorm_kernels.cu"],
+    extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
+)
+ext_modules.append(layernorm_extension)
 
 # Activation kernels.
-# activation_extension = CUDAExtension(
-#     name="vllm.activation_ops",
-#     sources=["csrc/activation.cpp", "csrc/activation_kernels.cu"],
-#     extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
-# )
-# ext_modules.append(activation_extension)
+activation_extension = CUDAExtension(
+    name="vllm_activation_ops",
+    sources=["csrc/activation.cpp", "csrc/activation_kernels.cu"],
+    extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
+)
+ext_modules.append(activation_extension)
 
+# Misc. CUDA utils.
+cuda_utils_extension = CUDAExtension(
+    name="vllm_cuda_utils",
+    sources=["csrc/cuda_utils.cpp", "csrc/cuda_utils_kernels.cu"],
+    extra_compile_args={
+        "cxx": CXX_FLAGS,
+        "nvcc": NVCC_FLAGS,
+    },
+)
+ext_modules.append(cuda_utils_extension)
 
 def get_path(*filepath) -> str:
     return os.path.join(ROOT_DIR, *filepath)

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 
-from vllm import activation_ops
+import vllm_activation_ops as activation_ops
 
 _ACTIVATION_REGISTRY = {
     "gelu": nn.GELU(),

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -100,22 +100,8 @@ class PagedAttention(nn.Module):
             input_metadata.block_tables,
             input_metadata.context_lens,
             block_size,
-            # input_metadata.max_context_len,
-            -1,
+            input_metadata.max_context_len,
         )
-        # single_query_cached_kv_attention(
-        #         attn_output,
-        #         query,
-        #         kcache,
-        #         vcache,
-        #         self.kv_head_mapping,
-        #         self.softmax_scale,
-        #         block_tables,
-        #         input_lengths,
-        #         block_size,
-        #         #max_s_tensor,
-        #         -1  # changed the kernel to not use this
-        #     )
 
     def forward(
         self,

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 
-from vllm import layernorm_ops
+import vllm_layernorm_ops as layernorm_ops
 
 
 class RMSNorm(nn.Module):

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -5,10 +5,21 @@ import uuid
 import psutil
 import torch
 
+import vllm_cuda_utils
+
 
 class Device(enum.Enum):
     GPU = enum.auto()
     CPU = enum.auto()
+
+
+def get_max_shared_memory_bytes(gpu: int = 0) -> int:
+    """Returns the maximum shared memory per thread block in bytes."""
+    # https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html
+    cudaDevAttrMaxSharedMemoryPerBlockOptin = 97  # pylint: disable=invalid-name
+    max_shared_mem = vllm_cuda_utils.get_device_attribute(
+        cudaDevAttrMaxSharedMemoryPerBlockOptin, gpu)
+    return int(max_shared_mem)
 
 
 class Counter:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Tuple
 
 import torch
 
-from vllm import cache_ops
+import vllm_cache_ops as cache_ops
 from vllm.config import CacheConfig, ModelConfig, ParallelConfig
 from vllm.logger import init_logger
 from vllm.utils import in_wsl

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -11,7 +11,7 @@ from vllm.model_executor.parallel_utils.parallel_state import (
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import SequenceData, SequenceGroupMetadata, SequenceOutputs
 from vllm.worker.cache_engine import CacheEngine
-from vllm.utils import get_gpu_memory
+from vllm.utils import get_gpu_memory, get_max_shared_memory_bytes
 
 
 class Worker:
@@ -125,6 +125,8 @@ class Worker:
     def init_cache_engine(self, cache_config: CacheConfig) -> None:
         self.cache_config = cache_config
         self.block_size = cache_config.block_size
+        _check_if_can_support_max_seq_len(self.scheduler_config.max_num_batched_tokens, # this should be max seq length
+                                          self.block_size)
         self.cache_engine = CacheEngine(
             self.cache_config, self.model_config, self.parallel_config)
         self.cache_events = self.cache_engine.events
@@ -312,3 +314,22 @@ def _pad_to_alignment(x: List[int], multiple_of: int) -> List[int]:
 
 def _pad_to_max(x: List[int], max_len: int) -> List[int]:
     return x + [0] * (max_len - len(x))
+
+def _check_if_can_support_max_seq_len(max_seq_len: int,
+                                      block_size: int) -> None:
+    # Follows the logic in
+    # attention_kernels.cu::single_query_cached_kv_attention_launcher
+    max_shared_mem = get_max_shared_memory_bytes()
+    float32_bytes = torch.finfo(torch.float).bits // 8
+    padded_max_seq_len = (
+        (max_seq_len + block_size - 1) / block_size) * block_size
+    # padded_max_seq_len + extra buffer
+    required_shared_mem = (padded_max_seq_len + 512) * float32_bytes
+    if padded_max_seq_len * float32_bytes > max_shared_mem:
+        raise RuntimeError(
+            f"vLLM cannot currently support max_model_len={max_seq_len} "
+            f"with block_size={block_size} on GPU with compute "
+            f"capability {torch.cuda.get_device_capability()} "
+            f"(required shared memory {required_shared_mem} > "
+            f"available shared memory {max_shared_mem}). "
+            "This will be fixed in a future release.")


### PR DESCRIPTION
This PR incorporate https://github.com/vllm-project/vllm/pull/1154 , and set a large enough shared memory if the max context length is -1 (which we use in ttgi).

The key change is:
```
  cudaFuncSetAttribute(                                                                       \
      vllm::single_query_cached_kv_attention_kernel<T, HEAD_SIZE, BLOCK_SIZE, NUM_THREADS>,   \
      cudaFuncAttributeMaxDynamicSharedMemorySize, shared_mem_size);                          \
```